### PR TITLE
Deprecate TechDocs GitHub Action

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,5 +10,5 @@ metadata:
     backstage.io/techdocs-ref: dir:.
 spec:
   type: library
-  lifecycle: experimental
+  lifecycle: deprecated
   owner: developer-productivity


### PR DESCRIPTION
It requires to much effort to keep this action up-to-date. Reverting to
docker compose.
